### PR TITLE
fix: use `Partial` type to set all parameters as optional

### DIFF
--- a/src/get-source.ts
+++ b/src/get-source.ts
@@ -36,9 +36,9 @@ export function getTypes(): string {
 function getImgixUrlParamsType(schema: Schema): string {
   return `
   /** @see {@link https://docs.imgix.com/apis/rendering} */
-  export type Params = ${schema.categoryValues
+  export type Params = Partial<${schema.categoryValues
     .map((category) => getCategoryInterfaceName(category))
-    .join(' & ')}`;
+    .join(' & ')}>`;
 }
 
 function getCategoryInterfaceName(category: CategoryValue): string {


### PR DESCRIPTION
Hey @JamieMason, Sherwin from imgix here 👋 

Thanks for all the hard work and thoughtfulness put into constructing these types from our parameter spec. The team and I are super excited to integrate this into imgix-url-params and eventually consume it in our other libraries.

I was in the middle of testing things out when I noticed that when importing the URL parameter types, it seems to expect all parameters to be specified.

https://user-images.githubusercontent.com/15919091/203207429-dfd43f44-17df-41f1-b33d-cff4de5b2a4a.mov

To work around this, I threw in a `Partial` around the `Params` definition so that each parameter under the different categories get marked as optional.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/15919091/203207771-f51ecafb-dcc6-43ff-8414-510cc7add949.png"> <img width="400" alt="image" src="https://user-images.githubusercontent.com/15919091/203209193-01da289b-1ee6-4875-86d6-659744774a5c.png">
