### PR TITLE
fix: adjust ratio types to include strings

### DIFF
--- a/src/get-source.ts
+++ b/src/get-source.ts
@@ -112,7 +112,7 @@ function getPropType(expect: Expect): string {
     return expect.possible_values.map((s) => `'${s}'`).join(' | ');
   if (expect.type === 'number') return 'number';
   if (expect.type === 'path') return 'string';
-  if (expect.type === 'ratio') return 'number';
+  if (expect.type === 'ratio') return 'number | `${string}:${string}`';
   if (expect.type === 'string') {
     if ('possible_values' in expect) {
       return expect.possible_values.map((s) => `'${s}'`).join(' | ');

--- a/src/get-source.ts
+++ b/src/get-source.ts
@@ -36,9 +36,9 @@ export function getTypes(): string {
 function getImgixUrlParamsType(schema: Schema): string {
   return `
   /** @see {@link https://docs.imgix.com/apis/rendering} */
-  export type Params = ${schema.categoryValues
+  export type Params = Partial<${schema.categoryValues
     .map((category) => getCategoryInterfaceName(category))
-    .join(' & ')}`;
+    .join(' & ')}>`;
 }
 
 function getCategoryInterfaceName(category: CategoryValue): string {
@@ -68,7 +68,7 @@ function getParamsInterface(
     return [tsdoc, `'${key}': ${type};`].join('\n');
   });
 
-  return [`export type ${name} = Partial<{`, ...props, '}>'].join('\n\n');
+  return [`export interface ${name} {`, ...props, '}'].join('\n\n');
 }
 
 function getHexColorType(): string {


### PR DESCRIPTION
Expands the definition of `ratio` types to include strings, e.g. `3:2` instead of `1.5` only.

## Before
```
(property) ImgixUrl.SizeParams.ar: number
Specifies an aspect ratio to maintain when resizing and cropping the image

@see — https://docs.imgix.com/apis/url/size/ar
```

## After
```
(property) ImgixUrl.SizeParams.ar: number | `${string}:${string}`
Specifies an aspect ratio to maintain when resizing and cropping the image

@see — https://docs.imgix.com/apis/url/size/ar
```

Note: It might be more clear to change this to `${number}:${number}` instead.