### PR TITLE
feat: add parameter dependencies in tsdoc

### DIFF
--- a/src/get-source.ts
+++ b/src/get-source.ts
@@ -58,10 +58,10 @@ function getParamsInterface(
 ): string {
   const props: string[] = entries.map(([key, value]) => {
     const type = getPropTypes(value);
-    let dependencies: string[][] = [];
+    // construct dependency list per parameter
     let dependencyTsdocLines: string[] = [];
     if ('depends' in value) {
-      value.depends.map((depend: string) => dependencies.push([depend.includes("=") ? depend.split("=")[0] : depend, depend]))
+      const dependencies: string[][] = Array.from(value.depends.map((depend: string) => [depend.includes("=") ? depend.split("=")[0] : depend, depend]))
       dependencyTsdocLines = Array.from(dependencies.map(dependency => `@see Depends on: {@link ${dependency[0]} | ${dependency[1]}}`));
     }
 

--- a/src/get-source.ts
+++ b/src/get-source.ts
@@ -58,8 +58,16 @@ function getParamsInterface(
 ): string {
   const props: string[] = entries.map(([key, value]) => {
     const type = getPropTypes(value);
+    let dependencies: string[][] = [];
+    let dependencyTsdocLines: string[] = [];
+    if ('depends' in value) {
+      value.depends.map((depend: string) => dependencies.push([depend.includes("=") ? depend.split("=")[0] : depend, depend]))
+      dependencyTsdocLines = Array.from(dependencies.map(dependency => `@see Depends on: {@link ${dependency[0]} | ${dependency[1]}}`));
+    }
+
     const tsdocLines = [
       value.short_description,
+      ...dependencyTsdocLines,
       'url' in value && `@see {@link ${value.url}}`,
     ]
       .filter(Boolean)


### PR DESCRIPTION
Appends a line to the tsdoc referencing each parameter that the given entry depends on, linking to the definition of those parameters. This should help users spend less time troubleshooting "why doesn't this parameter work even though I specified it" by increasing discoverability of other parameters and their type definitions.


https://user-images.githubusercontent.com/15919091/206655808-aa061e74-d648-4701-a0f6-bd78aae58b6f.mp4



## Before

```
(property) ImgixUrl.SizeParams.crop: "top" | "bottom" | "left" | "right" | "faces" | "entropy" | "edges" | "focalpoint"
Specifies how to crop an image.

@see — https://docs.imgix.com/apis/url/size/crop
```

## After

```
(property) ImgixUrl.SizeParams.crop: "top" | "bottom" | "left" | "right" | "faces" | "entropy" | "edges" | "focalpoint"
Specifies how to crop an image.

@see — Depends on: fit=crop

@see — https://docs.imgix.com/apis/url/size/crop
```